### PR TITLE
Enable multi-file cue support

### DIFF
--- a/qemu_1.10/qemu-0.10.0/cuesheet.h
+++ b/qemu_1.10/qemu-0.10.0/cuesheet.h
@@ -4,6 +4,7 @@
 typedef struct CueTrack {
     int lba;
     int is_audio;
+    char path[1024];
 } CueTrack;
 
 typedef struct CueSheet {

--- a/qemu_1.10/qemu-0.10.0/hw/cdaudio.c
+++ b/qemu_1.10/qemu-0.10.0/hw/cdaudio.c
@@ -1,5 +1,6 @@
 #include "hw.h"
 #include "cdaudio.h"
+#include "cuesheet.h"
 #include "bswap.h"
 
 #ifdef CONFIG_CDAUDIO
@@ -8,6 +9,7 @@ typedef struct CDAudioState {
     QEMUSoundCard card;
     SWVoiceOut *voice;
     BlockDriverState *bs;
+    BlockDriverState *track_bs[100];
     int playing;
     int cur_lba;
     int end_lba;
@@ -24,10 +26,31 @@ static void cdaudio_callback(void *opaque, int free)
                     s->playing, s->cur_lba, s->end_lba);
 
     while (free >= 2352 && s->playing && s->cur_lba < s->end_lba) {
-        if (!s->bs)
+        int t;
+        BlockDriverState *bs = NULL;
+        int off_lba = s->cur_lba;
+
+        for (t = cue_sheet.track_count - 1; t >= 0; t--) {
+            if (s->cur_lba >= cue_sheet.tracks[t].lba) {
+                break;
+            }
+        }
+
+        if (t >= 0 && cue_sheet.tracks[t].path[0]) {
+            if (!s->track_bs[t]) {
+                bdrv_file_open(&s->track_bs[t], cue_sheet.tracks[t].path, BDRV_O_RDONLY);
+            }
+            bs = s->track_bs[t];
+            off_lba = s->cur_lba - cue_sheet.tracks[t].lba;
+        } else {
+            bs = s->bs;
+        }
+
+        if (!bs)
             break;
-        CDAUDIO_DPRINTF("read lba=%d\n", s->cur_lba);
-        if (bdrv_pread(s->bs, (int64_t)s->cur_lba * 2352, sector, 2352) != 2352)
+
+        CDAUDIO_DPRINTF("read lba=%d track=%d off=%d\n", s->cur_lba, t, off_lba);
+        if (bdrv_pread(bs, (int64_t)off_lba * 2352, sector, 2352) != 2352)
             break;
 #ifndef WORDS_BIGENDIAN
         for (int i = 0; i < 2352; i += 2)
@@ -50,6 +73,7 @@ void cdaudio_init(BlockDriverState *bs)
     struct audsettings as = {44100, 2, AUD_FMT_S16, AUDIO_HOST_ENDIANNESS};
     AudioState *audio = AUD_init();
     cd_audio.bs = bs;
+    memset(cd_audio.track_bs, 0, sizeof(cd_audio.track_bs));
     AUD_register_card(audio, "cdaudio", &cd_audio.card);
     cd_audio.voice = AUD_open_out(&cd_audio.card, NULL, "cdaudio",
                                   &cd_audio, cdaudio_callback, &as);
@@ -59,6 +83,7 @@ void cdaudio_init(BlockDriverState *bs)
 void cdaudio_set_bs(BlockDriverState *bs)
 {
     cd_audio.bs = bs;
+    memset(cd_audio.track_bs, 0, sizeof(cd_audio.track_bs));
     CDAUDIO_DPRINTF("set_bs %p\n", bs);
 }
 

--- a/qemu_1.10/qemu-0.10.0/vl.c
+++ b/qemu_1.10/qemu-0.10.0/vl.c
@@ -199,6 +199,8 @@ static int cue_extract_bin(const char *cuefile, char *out, int out_size)
                 if (cue_sheet.track_count < 100) {
                     cue_sheet.tracks[cue_sheet.track_count].lba = msf_to_lba(m, s, fframe);
                     cue_sheet.tracks[cue_sheet.track_count].is_audio = cur_is_audio;
+                    pstrcpy(cue_sheet.tracks[cue_sheet.track_count].path,
+                            sizeof(cue_sheet.tracks[cue_sheet.track_count].path), cur_file);
                     cue_sheet.track_count++;
                 }
             }
@@ -207,6 +209,14 @@ static int cue_extract_bin(const char *cuefile, char *out, int out_size)
     fclose(f);
 
     if (cue_sheet.track_count > 0 && first_file[0]) {
+        int i;
+        for (i = 0; i < cue_sheet.track_count; i++) {
+            if (!path_is_absolute(cue_sheet.tracks[i].path)) {
+                char tmp[1024];
+                path_combine(tmp, sizeof(tmp), dir, cue_sheet.tracks[i].path);
+                pstrcpy(cue_sheet.tracks[i].path, sizeof(cue_sheet.tracks[i].path), tmp);
+            }
+        }
         pstrcpy(cue_sheet.bin_path, sizeof(cue_sheet.bin_path), first_file);
         if (!path_is_absolute(cue_sheet.bin_path)) {
             char tmp[1024];


### PR DESCRIPTION
## Summary
- expand cuesheet structures to remember file paths
- load per-track file names when parsing cue sheets
- play audio from the appropriate image file
- fix offset calculation when selecting track data

## Testing
- `./scripts/install_sdl12.sh`
- `./configure --target-list=i386-softmmu --enable-cdaudio`
- `make hw/cdaudio.o`
- `make hw/cdrom.o`


------
https://chatgpt.com/codex/tasks/task_e_6851cab8223c832c83b9ccdcde1668df