### PR TITLE
Add OpenAL audio backend for QEMU

### DIFF
--- a/qemu_1.10/qemu-0.10.0/Makefile
+++ b/qemu_1.10/qemu-0.10.0/Makefile
@@ -128,6 +128,9 @@ AUDIO_PT = yes
 AUDIO_PT_INT = yes
 AUDIO_OBJS += paaudio.o
 endif
+ifdef CONFIG_OPENAL
+AUDIO_OBJS += openalaudio.o
+endif
 ifdef AUDIO_PT
 LDFLAGS += -pthread
 endif

--- a/qemu_1.10/qemu-0.10.0/Makefile.target
+++ b/qemu_1.10/qemu-0.10.0/Makefile.target
@@ -536,6 +536,9 @@ endif
 ifdef CONFIG_OSS
 LIBS += $(CONFIG_OSS_LIB)
 endif
+ifdef CONFIG_OPENAL
+LIBS += $(CONFIG_OPENAL_LIB)
+endif
 
 SOUND_HW = sb16.o es1370.o ac97.o
 ifdef CONFIG_ADLIB

--- a/qemu_1.10/qemu-0.10.0/audio/audio_int.h
+++ b/qemu_1.10/qemu-0.10.0/audio/audio_int.h
@@ -205,6 +205,7 @@ extern struct audio_driver coreaudio_audio_driver;
 extern struct audio_driver dsound_audio_driver;
 extern struct audio_driver esd_audio_driver;
 extern struct audio_driver pa_audio_driver;
+extern struct audio_driver openal_audio_driver;
 extern struct mixeng_volume nominal_volume;
 
 void audio_pcm_init_info (struct audio_pcm_info *info, struct audsettings *as);

--- a/qemu_1.10/qemu-0.10.0/audio/openalaudio.c
+++ b/qemu_1.10/qemu-0.10.0/audio/openalaudio.c
@@ -1,0 +1,166 @@
+/*
+ * QEMU OpenAL audio driver based on PCem implementation
+ */
+#include "qemu-common.h"
+#include "audio.h"
+
+#ifdef __APPLE__
+#include <OpenAL/al.h>
+#include <OpenAL/alc.h>
+#else
+#include <AL/al.h>
+#include <AL/alc.h>
+#endif
+
+#define AUDIO_CAP "openal"
+#include "audio_int.h"
+
+#define NUM_BUFFERS 4
+
+typedef struct OpenALVoiceOut {
+    HWVoiceOut hw;
+    ALuint source;
+    ALuint buffers[NUM_BUFFERS];
+    int queued;
+} OpenALVoiceOut;
+
+static ALCdevice *al_dev;
+static ALCcontext *al_ctx;
+
+static void *openal_audio_init(void)
+{
+    al_dev = alcOpenDevice(NULL);
+    if (!al_dev) {
+        dolog("Could not open OpenAL device\n");
+        return NULL;
+    }
+    al_ctx = alcCreateContext(al_dev, NULL);
+    if (!al_ctx || !alcMakeContextCurrent(al_ctx)) {
+        dolog("Could not create OpenAL context\n");
+        if (al_ctx)
+            alcDestroyContext(al_ctx);
+        alcCloseDevice(al_dev);
+        return NULL;
+    }
+    return (void*)1;
+}
+
+static void openal_audio_fini(void *opaque)
+{
+    if (al_ctx) {
+        alcMakeContextCurrent(NULL);
+        alcDestroyContext(al_ctx);
+    }
+    if (al_dev) {
+        alcCloseDevice(al_dev);
+    }
+}
+
+static int openal_init_out(HWVoiceOut *hw, struct audsettings *as)
+{
+    OpenALVoiceOut *vo = (OpenALVoiceOut *)hw;
+    int i;
+
+    audio_pcm_init_info(&hw->info, as);
+    hw->samples = 1024;
+
+    alGenSources(1, &vo->source);
+    alGenBuffers(NUM_BUFFERS, vo->buffers);
+    vo->queued = 0;
+
+    for (i = 0; i < NUM_BUFFERS; i++) {
+        alSourceQueueBuffers(vo->source, 1, &vo->buffers[i]);
+        vo->queued++;
+    }
+    alSourcePlay(vo->source);
+
+    return 0;
+}
+
+static void openal_fini_out(HWVoiceOut *hw)
+{
+    OpenALVoiceOut *vo = (OpenALVoiceOut *)hw;
+    alSourceStop(vo->source);
+    if (vo->queued) {
+        alSourceUnqueueBuffers(vo->source, vo->queued, vo->buffers);
+        vo->queued = 0;
+    }
+    alDeleteSources(1, &vo->source);
+    alDeleteBuffers(NUM_BUFFERS, vo->buffers);
+}
+
+static int openal_run_out(HWVoiceOut *hw)
+{
+    OpenALVoiceOut *vo = (OpenALVoiceOut *)hw;
+    int processed;
+    int live;
+    int decr;
+    int rpos;
+    struct st_sample *src;
+    int16_t tmp[1024*2];
+
+    live = audio_pcm_hw_get_live_out(hw);
+    if (!live)
+        return 0;
+
+    alGetSourcei(vo->source, AL_BUFFERS_PROCESSED, &processed);
+    while (processed-- > 0) {
+        ALuint buf;
+        alSourceUnqueueBuffers(vo->source, 1, &buf);
+        vo->queued--;
+    }
+
+    decr = live;
+    rpos = hw->rpos;
+    if (decr > hw->samples)
+        decr = hw->samples;
+
+    src = hw->mix_buf + rpos;
+    hw->clip(tmp, src, decr);
+    alBufferData(vo->buffers[0], AL_FORMAT_STEREO16, tmp, decr << hw->info.shift, hw->info.freq);
+    alSourceQueueBuffers(vo->source, 1, &vo->buffers[0]);
+    vo->queued++;
+
+    if (vo->queued > NUM_BUFFERS)
+        vo->queued = NUM_BUFFERS;
+
+    if (decr)
+        alSourcePlay(vo->source);
+
+    hw->rpos = (rpos + decr) % hw->samples;
+
+    return decr;
+}
+
+static int openal_write_out(SWVoiceOut *sw, void *buf, int len)
+{
+    return audio_pcm_sw_write(sw, buf, len);
+}
+
+static struct audio_pcm_ops openal_pcm_ops = {
+    .init_out  = openal_init_out,
+    .fini_out  = openal_fini_out,
+    .run_out   = openal_run_out,
+    .write     = openal_write_out,
+    .ctl_out   = NULL,
+    .init_in   = NULL,
+    .fini_in   = NULL,
+    .run_in    = NULL,
+    .read      = NULL,
+    .ctl_in    = NULL,
+};
+
+struct audio_driver openal_audio_driver = {
+    .name           = "openal",
+    .descr          = "OpenAL audio output",
+    .options        = NULL,
+    .init           = openal_audio_init,
+    .fini           = openal_audio_fini,
+    .pcm_ops        = &openal_pcm_ops,
+    .can_be_default = 1,
+    .max_voices_out = 1,
+    .max_voices_in  = 0,
+    .voice_size_out = sizeof(OpenALVoiceOut),
+    .voice_size_in  = 0,
+};
+

--- a/qemu_1.10/qemu-0.10.0/configure
+++ b/qemu_1.10/qemu-0.10.0/configure
@@ -205,41 +205,41 @@ OS_CFLAGS="-mno-cygwin"
 if [ "$cpu" = "i386" ] ; then
     kqemu="yes"
 fi
-audio_possible_drivers="sdl"
+audio_possible_drivers="sdl openal"
 ;;
 MINGW32*)
 mingw32="yes"
 if [ "$cpu" = "i386" ] ; then
     kqemu="yes"
 fi
-audio_possible_drivers="dsound sdl fmod"
+audio_possible_drivers="dsound sdl fmod openal"
 ;;
 GNU/kFreeBSD)
-audio_drv_list="oss"
-audio_possible_drivers="oss sdl esd pa"
+audio_drv_list="oss,openal"
+audio_possible_drivers="oss sdl esd pa openal"
 if [ "$cpu" = "i386" -o "$cpu" = "x86_64" ] ; then
     kqemu="yes"
 fi
 ;;
 FreeBSD)
 bsd="yes"
-audio_drv_list="oss"
-audio_possible_drivers="oss sdl esd pa"
+audio_drv_list="oss,openal"
+audio_possible_drivers="oss sdl esd pa openal"
 if [ "$cpu" = "i386" -o "$cpu" = "x86_64" ] ; then
     kqemu="yes"
 fi
 ;;
 NetBSD)
 bsd="yes"
-audio_drv_list="oss"
-audio_possible_drivers="oss sdl esd"
+audio_drv_list="oss,openal"
+audio_possible_drivers="oss sdl esd openal"
 oss_lib="-lossaudio"
 ;;
 OpenBSD)
 bsd="yes"
 openbsd="yes"
-audio_drv_list="oss"
-audio_possible_drivers="oss sdl esd"
+audio_drv_list="oss,openal"
+audio_possible_drivers="oss sdl esd openal"
 oss_lib="-lossaudio"
 ;;
 Darwin)
@@ -259,7 +259,7 @@ fi
 darwin_user="yes"
 cocoa="yes"
 audio_drv_list="coreaudio"
-audio_possible_drivers="coreaudio sdl fmod"
+audio_possible_drivers="coreaudio sdl fmod openal"
 OS_LDFLAGS="-framework CoreFoundation -framework IOKit"
 ;;
 SunOS)
@@ -291,23 +291,23 @@ SunOS)
         fi
     fi
     if test -f /usr/include/sys/soundcard.h ; then
-        audio_drv_list="oss"
+        audio_drv_list="oss,openal"
     fi
-    audio_possible_drivers="oss sdl"
+    audio_possible_drivers="oss sdl openal"
 ;;
 AIX)
 aix="yes"
 make="gmake"
 ;;
 *)
-audio_drv_list="oss"
-audio_possible_drivers="oss alsa sdl esd pa"
+audio_drv_list="oss,openal"
+audio_possible_drivers="oss alsa sdl esd pa openal"
 linux="yes"
 linux_user="yes"
 usb="linux"
 if [ "$cpu" = "i386" -o "$cpu" = "x86_64" ] ; then
     kqemu="yes"
-    audio_possible_drivers="$audio_possible_drivers fmod"
+    audio_possible_drivers="$audio_possible_drivers fmod openal"
 fi
 ;;
 esac
@@ -917,7 +917,7 @@ for drv in $audio_drv_list; do
         "pa_simple *s = NULL; pa_simple_free(s); return 0;"
     ;;
 
-    oss|sdl|core|wav|dsound)
+    oss|sdl|core|wav|dsound|openal)
     # XXX: Probes for CoreAudio, DirectSound, SDL(?)
     ;;
 
@@ -1381,6 +1381,8 @@ for drv in $audio_drv_list; do
         echo "CONFIG_FMOD_INC=$fmod_inc" >> $config_mak
     elif test "$drv" = "oss"; then
         echo "CONFIG_OSS_LIB=$oss_lib" >> $config_mak
+    elif test "$drv" = "openal"; then
+        echo "CONFIG_OPENAL_LIB=-lopenal" >> $config_mak
     fi
 done
 echo "" >>$config_h


### PR DESCRIPTION
## Summary
- port OpenAL audio output from PCem to QEMU 0.10
- enable detection of OpenAL in `configure`
- link with OpenAL when configured
- expose the new driver via `audio_int.h`

## Testing
- `./configure --target-list=i386-softmmu --audio-drv-list=openal,oss,sdl --disable-werror`
- `make -j2`

------
https://chatgpt.com/codex/tasks/task_e_6851d43d8708832cb3632d0da77055b1