### PR TITLE
Add simplified CUE parser to PCem

### DIFF
--- a/pcem/includes/private/dosbox/cdrom.h
+++ b/pcem/includes/private/dosbox/cdrom.h
@@ -158,6 +158,7 @@ class CDROM_Interface_Image : public CDROM_Interface {
         bool CanReadPVD(TrackFile *file, int sectorSize, bool mode2);
         // cue sheet processing
         bool LoadCueSheet(char *cuefile);
+        bool LoadCueSheetSimple(char *cuefile);
         bool GetRealFileName(std::string &filename, std::string &pathname);
         bool GetCueKeyword(std::string &keyword, std::istream &in);
         bool GetCueFrame(int &frames, std::istream &in);


### PR DESCRIPTION
## Summary
- extend PCem CDROM class with `LoadCueSheetSimple` based on QEMU
- call the new parser as a fallback when loading devices
- expose the new method in the header

## Testing
- `cmake -S pcem -B pcem/build`
- `cmake --build pcem/build -j4`


------
https://chatgpt.com/codex/tasks/task_e_6851ddc01af8832c9aa21fd7b9c4d16c